### PR TITLE
Twisted 12.3.0 Unicode domain -> ASCII workaround must happen before initializing base class

### DIFF
--- a/punjab/session.py
+++ b/punjab/session.py
@@ -40,13 +40,13 @@ class XMPPClientConnector(SRVConnector):
     """
     def __init__(self, client_reactor, domain, factory):
         """ Init """
-        SRVConnector.__init__(self, client_reactor, 'xmpp-client', domain, factory)
         if isinstance(domain, unicode):
             warnings.warn(
                 "Domain argument to XMPPClientConnector should be bytes, "
                 "not unicode",
                 stacklevel=2)
             domain = domain.encode('ascii')
+        SRVConnector.__init__(self, client_reactor, 'xmpp-client', domain, factory)
         self.timeout = [1,3]
 
     def pickServer(self):


### PR DESCRIPTION
This is a fix on top of the patch in #27 and also addresses #25. The original patch in #27 didn't work for me, as the check for Unicode happens too late, after the basse class has already been initialized.
