### PR TITLE
Add BOSH nack for undelivered messages

### DIFF
--- a/punjab/session.py
+++ b/punjab/session.py
@@ -615,12 +615,32 @@ class Session(jabber.JabberClientFactory, server.Session):
         for priority, query in emptyLists:
             del observers[priority][query]
 
+    def _handle_missed_messages(self):
+        """Return the messages with an error."""
+        for elem in self.elems:
+            elemName = elem.name.lower()
+            if elemName in (u'message', u'iq'):
+                elem['type'] = 'error'
+                error = elem.addElement('error')
+                error.addElement(
+                    'recipient-unavailable'
+                    if elemName == u'message' else
+                    'service-unavailable'
+                )
+                self.xmlstream.send(elem)
+
     def disconnect(self):
         """
         Disconnect from the xmpp server.
         """
         if not getattr(self, 'xmlstream',None):
             return
+
+        if self.elems and self.xmlstream:
+            try:
+                self._handle_missed_messages()
+            except Exception:
+                log.err('Failed to notify service of delivery failure.')
 
         if self.xmlstream:
             #sh = "<presence type='unavailable' xmlns='jabber:client'/>"

--- a/tests/xep206.py
+++ b/tests/xep206.py
@@ -7,6 +7,8 @@ from twisted.python import log
 from punjab.httpb import *
 import test_basic
 
+from punjab import session
+
 class DummyClient:
     """
     a client for testing
@@ -17,6 +19,30 @@ class DummyTransport:
     a transport for testing
     """
 
+    def loseConnection(self):
+        return None
+
+
+class DummyXmlStream(object):
+    """
+    An xmlstream for testing
+    """
+
+    def __init__(self):
+        self.elements = []
+        self.transport = DummyTransport()
+
+    def send(self, element):
+        self.elements.append(element)
+
+
+class DummyPint(object):
+    """
+    A `pint` input for testing
+    """
+
+    def __init__(self):
+        self.v = False
 
 
 class XEP0206TestCase(test_basic.TestCase):
@@ -47,3 +73,59 @@ class XEP0206TestCase(test_basic.TestCase):
         d = self.proxy.connect(BOSH_XML).addCallback(_testSessionCreate)
         return d
 
+
+class DeliveryFailureTestCase(XEP0206TestCase):
+    """
+    Tests for the XEP0206 message delivery failure NACK feature.
+    """
+
+    def setUp(self):
+        self.xmlstream = DummyXmlStream()
+        self.session = session.Session(
+            DummyPint(),
+            {
+                'rid': 0,
+                'to': '',
+                'route': 'xmpp:127.0.0.1:8080',
+            },  # Dummy values to satisfy the constructor. Not needed in tests.
+        )
+        self.session.xmlstream = self.xmlstream
+
+    def tearDown(self):
+        del self.session
+
+    def test_skips_presence(self):
+        """
+        Test that the NACK skips presence elements.
+        """
+        sentinel = domish.Element((None, 'presence'))
+        self.session.elems.append(sentinel)
+        self.session.disconnect()
+        assert sentinel not in self.xmlstream.elements
+
+    def test_sends_messages(self):
+        """
+        Test that the NACK sends message elements.
+        """
+        sentinel = domish.Element((None, 'message'))
+        self.session.elems.append(sentinel)
+        self.session.disconnect()
+        assert sentinel in self.xmlstream.elements
+
+    def test_sends_iq(self):
+        """
+        Test that the NACK sends iq elements.
+        """
+        sentinel = domish.Element((None, 'iq'))
+        self.session.elems.append(sentinel)
+        self.session.disconnect()
+        assert sentinel in self.xmlstream.elements
+
+    def test_errors_dont_bubble_up(self):
+        """
+        Test that NACK failures don't tank the service
+        """
+        def fail(*args, **kwargs):
+            raise Exception("You shouldn't see this.")
+        self.session._handle_missed_messages = fail
+        self.session.disconnect()

--- a/tests/xep206.py
+++ b/tests/xep206.py
@@ -101,7 +101,7 @@ class DeliveryFailureTestCase(XEP0206TestCase):
         sentinel = domish.Element((None, 'presence'))
         self.session.elems.append(sentinel)
         self.session.disconnect()
-        assert sentinel not in self.xmlstream.elements
+        self.assertTrue(sentinel not in self.xmlstream.elements)
 
     def test_sends_messages(self):
         """
@@ -110,7 +110,7 @@ class DeliveryFailureTestCase(XEP0206TestCase):
         sentinel = domish.Element((None, 'message'))
         self.session.elems.append(sentinel)
         self.session.disconnect()
-        assert sentinel in self.xmlstream.elements
+        self.assertTrue(sentinel in self.xmlstream.elements)
 
     def test_sends_iq(self):
         """
@@ -119,7 +119,7 @@ class DeliveryFailureTestCase(XEP0206TestCase):
         sentinel = domish.Element((None, 'iq'))
         self.session.elems.append(sentinel)
         self.session.disconnect()
-        assert sentinel in self.xmlstream.elements
+        self.assertTrue(sentinel in self.xmlstream.elements)
 
     def test_errors_dont_bubble_up(self):
         """


### PR DESCRIPTION
XEP-0206 provides for an optional error response when
the BOSH endpoint fails to deliver a stanza to the client.
This patch adds the writing of an appropriate error response
for message and iq stanzas back to the stream if they are not
delivered by the time a session disconnect is triggered.