### PR TITLE
Add optional strports input to the twistd plugin

### DIFF
--- a/punjab/__init__.py
+++ b/punjab/__init__.py
@@ -4,6 +4,7 @@ Punjab - multiple http interfaces to jabber.
 """
 
 from twisted.application import service
+from twisted.application import strports
 from twisted.python import log
 
 
@@ -83,7 +84,14 @@ def makeService(config):
     else:
         site = server.Site(r)
 
-    if config['ssl']:
+    if config['strports']:
+        for strport in config['strports']:
+            sm = strports.service(
+                strport,
+                site,
+            )
+            sm.setServiceParent(serviceCollection)
+    elif config['ssl']:
         from OpenSSL import SSL
         from punjab.ssl import OpenSSLContextFactoryChaining
         ssl_context = OpenSSLContextFactoryChaining(config['ssl_privkey'],

--- a/twisted/plugins/punjab_plugin.py
+++ b/twisted/plugins/punjab_plugin.py
@@ -12,6 +12,7 @@ class Options(usage.Options):
     optParameters = [
         ('host', None, 'localhost', "The hostname sent in the HTTP header of BOSH requests"),
         ('port', None, 5280, "HTTP Port for BOSH connections"),
+        ('strports', None, [], "String description for a listening Endpoint"),
         ('httpb', 'b', "http-bind", "URL path for BOSH resource."),
         ('polling', None, '15', "Seconds allowed between client polling requests"),
         ('html_dir', None, "./html", "The path were static html files are served."),
@@ -35,6 +36,15 @@ class Options(usage.Options):
     optFlags = [
         ('verbose', 'v', 'Show traffic and verbose logging.'),
     ]
+
+    def __init__(self):
+        usage.Options.__init__(self)
+        self['strports'] = []
+
+    def opt_strports(self, strport):
+        """Add a strport definition to the list."""
+        self['strports'].append(strport)
+
 
 class ServiceFactory(object):
     implements(IServiceMaker, IPlugin)


### PR DESCRIPTION
The t.a.strports module provides a parser for the simplified string
description of listening ports that is used to generate Endpoints. This
allows services to restart and change the listening connection settings
without needing to adjust the code that returns a Service implementation. It
also standardises the configuration of SSL/TLS listening ports so custom options
are not required to collect keys or interface bindings.

This patch maintains backwards compatibility with the original method of selecting
a port and settings by making the usage of `strports` optional. If `strports` are given
they override the original method of port configuration to avoid having an errant
listener on the default port and/or having port conflicts when `strports` is used to
listen on the default port as well.