### PR TITLE
Don't build whole xml tree for stanza payload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
 
 script:
   - flake8 punjab
-  - cd tests;trial xep124;trial testparser;trial xep206
+  - cd tests;export PYTHONPATH=${pwd};trial xep124;trial testparser;trial xep206

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ python:
     - 2.7
 
 env:
-  - TWISTED=svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk PYOPENSSL=PyOpenSSL
+  - TWISTED=git+https://github.com/twisted/twisted.git@trunk PYOPENSSL=PyOpenSSL
   - TWISTED=Twisted==16.1.1 PYOPENSSL=PyOpenSSL
   - TWISTED=Twisted==16.1.0 PYOPENSSL=PyOpenSSL
   - TWISTED=Twisted==16.0.0 PYOPENSSL=PyOpenSSL
   - TWISTED=Twisted==15.5.0 PYOPENSSL=PyOpenSSL
   - TWISTED=Twisted==15.4.0 PYOPENSSL=PyOpenSSL
   - TWISTED=Twisted==15.3.0 PYOPENSSL=PyOpenSSL
-  - TWISTED=svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk PYOPENSSL=
+  - TWISTED=git+https://github.com/twisted/twisted.git@trunk PYOPENSSL=
   - TWISTED=Twisted==16.1.1 PYOPENSSL=
   - TWISTED=Twisted==16.1.0 PYOPENSSL=
   - TWISTED=Twisted==16.0.0 PYOPENSSL=

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 install:
   - pip install flake8
   - pip install service_identity
-  - pip install $TWISTED --use-mirrors
+  - pip install $TWISTED
   - 'test -n "$PYOPENSSL" && pip install $PYOPENSSL --use-mirrors || true'
   - python setup.py install
 

--- a/punjab/jabber.py
+++ b/punjab/jabber.py
@@ -68,11 +68,12 @@ class JabberClientFactory(xmlstream.XmlStreamFactory):
 
 
 class ShallowExpatElementStream(ExpatElementStream):
-    """Modification of ExpatElementStream that doesn't build xml tree for stanza payload.
+    """Modification of parser that doesn't build xml tree for stanza payload.
 
-    Make stream parser handle only top level stanza tags. In this way payload (all xml elements with depth > 1)
-    will not be parsed into xml tree. This optimization would particularly be useful for <iq> stanzas,
-    as they may contain large payload (e.g. roster)
+    Make stream parser handle only top level stanza tags. In this way payload
+    (all xml elements with depth > 1) will not be parsed into xml tree. This
+    optimization would particularly be useful for <iq> stanzas, as they may
+    contain large payload (e.g. roster)
 
     """
     STANZA_TYPES = [u'message', u'presence', u'iq']
@@ -158,7 +159,10 @@ class PunjabAuthenticator(xmlstream.ConnectAuthenticator):
 
     def _reset(self, shallow=False):
         # need this to be in xmlstream
-        stream = ShallowExpatElementStream() if shallow else domish.elementStream()
+        if shallow:
+            stream = ShallowExpatElementStream()
+        else:
+            stream = domish.elementStream()
         stream.DocumentStartEvent = self.xmlstream.onDocumentStart
         stream.ElementEvent = self.xmlstream.onElement
         stream.DocumentEndEvent = self.xmlstream.onDocumentEnd

--- a/punjab/session.py
+++ b/punjab/session.py
@@ -706,7 +706,8 @@ class Session(jabber.JabberClientFactory, server.Session):
         if len(self.waiting_requests) > 0:
             self._wrPop([s])
 
-        self.authenticator._reset()
+        # Use shallow parser if use_raw is set. No need to build whole xml tree for stanza payload.
+        self.authenticator._reset(shallow=self.use_raw)
         if self.use_raw:
             self.raw_buffer = u""
 

--- a/punjab/session.py
+++ b/punjab/session.py
@@ -706,7 +706,8 @@ class Session(jabber.JabberClientFactory, server.Session):
         if len(self.waiting_requests) > 0:
             self._wrPop([s])
 
-        # Use shallow parser if use_raw is set. No need to build whole xml tree for stanza payload.
+        # Use shallow parser if use_raw is set.
+        # No need to build whole xml tree for stanza payload.
         self.authenticator._reset(shallow=self.use_raw)
         if self.use_raw:
             self.raw_buffer = u""


### PR DESCRIPTION
Some <iq> stanzas (with roster for example) can contain huge amount of xml, which is all parsed into xml tree even if use_raw=True. Because of this punjab can consume large amount of RAM (possibly because of python memory fragmentation http://www.gossamer-threads.com/lists/python/python/1162114) and CPU (to create domish.Element() instances).

ShallowExpatElementStream overrides _onStartElement() and _onEndElement() methods of regular parser to avoid building whole tree, which is done by default in domish.py:ExpatElementStream.